### PR TITLE
Add support for failover, geolocation, and latency routing policy to terraform-aws-route53-record

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,6 @@ Limitations
 
 * Does not support the following blocks:
 
-    * failover_routing_policy
-    * geolocation_routing_policy
     * latency_routing_policy
     * weighted_routing_policy
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ Limitations
 
 * Does not support the following blocks:
 
-    * latency_routing_policy
     * weighted_routing_policy
 
 * Does not support the following arguments:

--- a/examples/failover/terragrunt.hcl
+++ b/examples/failover/terragrunt.hcl
@@ -3,22 +3,22 @@ include {
 }
 
 terraform {
-  source = "git@github.com:techservicesillinois/terraform-aws-route53-record?ref=v3.0.0"
+  source = "git@github.com:techservicesillinois/terraform-aws-route53-record"
 }
 
 inputs = {
   hostname = "test"
-  domain = "courses.illinois.edu"
-  type   = "A"
-  ttl    = 5
+  domain   = "courses.illinois.edu"
+  type     = "A"
+  ttl      = 5
 
   set_identifier = "failover"
 
   failover_routing_policy = {
     type = "SECONDARY"
   }
-  
+
   records = [
-      "192.168.1.64",
+    "192.168.1.64",
   ]
 }

--- a/examples/failover/terragrunt.hcl
+++ b/examples/failover/terragrunt.hcl
@@ -1,0 +1,24 @@
+include {
+  path = "${find_in_parent_folders()}"
+}
+
+terraform {
+  source = "git@github.com:techservicesillinois/terraform-aws-route53-record?ref=v3.0.0"
+}
+
+inputs = {
+  hostname = "test"
+  domain = "courses.illinois.edu"
+  type   = "A"
+  ttl    = 5
+
+  set_identifier = "failover"
+
+  failover_routing_policy = {
+    type = "SECONDARY"
+  }
+  
+  records = [
+      "192.168.1.64",
+  ]
+}

--- a/examples/geolocation/terragrunt.hcl
+++ b/examples/geolocation/terragrunt.hcl
@@ -3,22 +3,22 @@ include {
 }
 
 terraform {
-  source = "git@github.com:techservicesillinois/terraform-aws-route53-record?ref=v1.0.0"
+  source = "git@github.com:techservicesillinois/terraform-aws-route53-record"
 }
 
 inputs = {
   hostname = "test"
-  domain = "courses.illinois.edu"
-  type   = "A"
-  ttl    = 5
+  domain   = "courses.illinois.edu"
+  type     = "A"
+  ttl      = 5
 
   set_identifier = "geolocation"
 
   geolocation_routing_policy = {
-    continent = "NA"  # North America
+    continent = "NA" # North America
   }
 
   records = [
-      "192.168.1.128",
+    "192.168.1.128",
   ]
 }

--- a/examples/geolocation/terragrunt.hcl
+++ b/examples/geolocation/terragrunt.hcl
@@ -1,0 +1,24 @@
+include {
+  path = "${find_in_parent_folders()}"
+}
+
+terraform {
+  source = "git@github.com:techservicesillinois/terraform-aws-route53-record?ref=v1.0.0"
+}
+
+inputs = {
+  hostname = "test"
+  domain = "courses.illinois.edu"
+  type   = "A"
+  ttl    = 5
+
+  set_identifier = "geolocation"
+
+  geolocation_routing_policy = {
+    continent = "NA"  # North America
+  }
+
+  records = [
+      "192.168.1.128",
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,16 @@ resource "aws_route53_record" "default" {
   type    = var.type
   ttl     = var.ttl
 
+  set_identifier  = var.set_identifier
   health_check_id = var.health_check_id
+
+  dynamic "failover_routing_policy" {
+    for_each = toset(var.failover_routing_policy != null ? [var.failover_routing_policy] : [])
+
+    content {
+      type = failover_routing_policy.value["type"]
+    }
+  }
 
   records = var.records
 }

--- a/main.tf
+++ b/main.tf
@@ -15,5 +15,15 @@ resource "aws_route53_record" "default" {
     }
   }
 
+  dynamic "geolocation_routing_policy" {
+    for_each = toset(var.geolocation_routing_policy != null ? [var.geolocation_routing_policy] : [])
+
+    content {
+      continent   = lookup(geolocation_routing_policy.value, "continent", null)
+      country     = lookup(geolocation_routing_policy.value, "country", null)
+      subdivision = lookup(geolocation_routing_policy.value, "subdivision", null)
+    }
+  }
+
   records = var.records
 }

--- a/main.tf
+++ b/main.tf
@@ -25,5 +25,14 @@ resource "aws_route53_record" "default" {
     }
   }
 
+  dynamic "latency_routing_policy" {
+    for_each = toset(var.latency_routing_policy != null ? [var.latency_routing_policy] : [])
+
+    content {
+      region = latency_routing_policy.value["region"]
+    }
+  }
+
+
   records = var.records
 }

--- a/variables.tf
+++ b/variables.tf
@@ -38,3 +38,9 @@ variable "failover_routing_policy" {
   type        = map(any)
   default     = null
 }
+
+variable "geolocation_routing_policy" {
+  description = "A block indicating a routing policy based on the geolocation of the requestor. Conflicts with any other routing policy."
+  type        = map(any)
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -21,7 +21,20 @@ variable "records" {
   type        = list(string)
 }
 
+variable "set_identifier" {
+  description = "Unique identifier to differentiate records with routing policies from one another. Required if using failover, geolocation, latency, or weighted routing policies documented below."
+  type        = string
+  default     = null
+}
+
 variable "health_check_id" {
   description = "The health check the record should be associated with."
-  default     = ""
+  type        = string
+  default     = null
+}
+
+variable "failover_routing_policy" {
+  description = "A block indicating the routing behavior when associated health check fails. Conflicts with any other routing policy."
+  type        = map(any)
+  default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -44,3 +44,9 @@ variable "geolocation_routing_policy" {
   type        = map(any)
   default     = null
 }
+
+variable "latency_routing_policy" {
+  description = "A block indicating a routing policy based on the latency between the requestor and an AWS region."
+  type        = map(any)
+  default     = null
+}


### PR DESCRIPTION
This very old pull request may prove useful if IAMU pursues multi-region support for the Shibboleth IdP. It's being pushed under a more meaningful branch name.